### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CE002_Srings/README.md
+++ b/CE002_Srings/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [CE2 Notes](https://github.com/DipsanaRoy/c-extensions/main/tree/CE002_Srings/CE2_NOTES.md)
+- [CE2 Notes](https://github.com/DipsanaRoy/c-extensions/blob/main/CE002_Srings/CE2_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.