### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CE003_File_IO/README.md
+++ b/CE003_File_IO/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [CE3 Notes](https://github.com/DipsanaRoy/c-extensions/main/tree/CE003_File_IO/CE3_NOTES.md)
+- [CE3 Notes](https://github.com/DipsanaRoy/c-extensions/blob/main/CE003_File_IO/CE3_NOTES.md)
 
 *Happy Learning!*
 

--- a/CE003_Try_Out/README.md
+++ b/CE003_Try_Out/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [CT3 Notes](https://github.com/DipsanaRoy/c-extensions/main/tree/CE003_Try_Out/CT3_NOTES.md)
+- [CT3 Notes](https://github.com/DipsanaRoy/c-extensions/blob/main/CE003_Try_Out/CT3_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.