### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CE005_goto/README.md
+++ b/CE005_goto/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [CE5 Notes](https://github.com/DipsanaRoy/c-extensions/main/tree/CE005_goto/CE5_GOTO.md)
+- [CE5 Notes](https://github.com/DipsanaRoy/c-extensions/blob/main/CE005_goto/CE5_GOTO.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.