### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CE006_Recursion/README.md
+++ b/CE006_Recursion/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [CE6 Notes](https://github.com/DipsanaRoy/c-extensions/main/tree/CE006_Recursion/CE6_NOTES.md)
+- [CE6 Notes](https://github.com/DipsanaRoy/c-extensions/blob/main/CE006_Recursion/CE6_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.