### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CE007_Math_Functions/README.md
+++ b/CE007_Math_Functions/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [CE7 Notes](https://github.com/DipsanaRoy/c-extensions/main/tree/CE007_Math_Functions/CE7_NOTES.md)
+- [CE7 Notes](https://github.com/DipsanaRoy/c-extensions/blob/main/CE007_Math_Functions/CE7_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.